### PR TITLE
fix(configure) check for the HTMLImports polyfill

### DIFF
--- a/dist/amd/aurelia-html-import-template-loader.js
+++ b/dist/amd/aurelia-html-import-template-loader.js
@@ -149,7 +149,7 @@ define(['exports', 'aurelia-loader', 'aurelia-pal'], function (exports, _aurelia
   function configure(config) {
     config.aurelia.loader.useTemplateLoader(new HTMLImportTemplateLoader());
 
-    if (!('import' in document.createElement('link'))) {
+    if (!('import' in document.createElement('link')) && !('HTMLImports' in window)) {
       var _name = config.aurelia.loader.normalizeSync('aurelia-html-import-template-loader');
       var importsName = config.aurelia.loader.normalizeSync('webcomponentsjs/HTMLImports.min', _name);
       return config.aurelia.loader.loadModule(importsName);

--- a/dist/aurelia-html-import-template-loader.js
+++ b/dist/aurelia-html-import-template-loader.js
@@ -135,7 +135,8 @@ export class HTMLImportTemplateLoader {
 export function configure(config: Object): Promise<void> {
   config.aurelia.loader.useTemplateLoader(new HTMLImportTemplateLoader());
 
-  if (!('import' in document.createElement('link'))) {
+  // Check for native or polyfilled HTML imports support.
+  if (!('import' in document.createElement('link')) && !('HTMLImports' in window)) {
     let name = config.aurelia.loader.normalizeSync('aurelia-html-import-template-loader');
     let importsName = config.aurelia.loader.normalizeSync('webcomponentsjs/HTMLImports.min', name);
     return config.aurelia.loader.loadModule(importsName);

--- a/dist/commonjs/aurelia-html-import-template-loader.js
+++ b/dist/commonjs/aurelia-html-import-template-loader.js
@@ -152,7 +152,7 @@ exports.HTMLImportTemplateLoader = HTMLImportTemplateLoader;
 function configure(config) {
   config.aurelia.loader.useTemplateLoader(new HTMLImportTemplateLoader());
 
-  if (!('import' in document.createElement('link'))) {
+  if (!('import' in document.createElement('link')) && !('HTMLImports' in window)) {
     var _name = config.aurelia.loader.normalizeSync('aurelia-html-import-template-loader');
     var importsName = config.aurelia.loader.normalizeSync('webcomponentsjs/HTMLImports.min', _name);
     return config.aurelia.loader.loadModule(importsName);

--- a/dist/es6/aurelia-html-import-template-loader.js
+++ b/dist/es6/aurelia-html-import-template-loader.js
@@ -135,7 +135,8 @@ export class HTMLImportTemplateLoader {
 export function configure(config: Object): Promise<void> {
   config.aurelia.loader.useTemplateLoader(new HTMLImportTemplateLoader());
 
-  if (!('import' in document.createElement('link'))) {
+  // Check for native or polyfilled HTML imports support.
+  if (!('import' in document.createElement('link')) && !('HTMLImports' in window)) {
     let name = config.aurelia.loader.normalizeSync('aurelia-html-import-template-loader');
     let importsName = config.aurelia.loader.normalizeSync('webcomponentsjs/HTMLImports.min', name);
     return config.aurelia.loader.loadModule(importsName);

--- a/dist/system/aurelia-html-import-template-loader.js
+++ b/dist/system/aurelia-html-import-template-loader.js
@@ -10,7 +10,7 @@ System.register(['aurelia-loader', 'aurelia-pal'], function (_export) {
   function configure(config) {
     config.aurelia.loader.useTemplateLoader(new HTMLImportTemplateLoader());
 
-    if (!('import' in document.createElement('link'))) {
+    if (!('import' in document.createElement('link')) && !('HTMLImports' in window)) {
       var _name = config.aurelia.loader.normalizeSync('aurelia-html-import-template-loader');
       var importsName = config.aurelia.loader.normalizeSync('webcomponentsjs/HTMLImports.min', _name);
       return config.aurelia.loader.loadModule(importsName);

--- a/src/html-import-template-loader.js
+++ b/src/html-import-template-loader.js
@@ -135,7 +135,8 @@ export class HTMLImportTemplateLoader {
 export function configure(config: Object): Promise<void> {
   config.aurelia.loader.useTemplateLoader(new HTMLImportTemplateLoader());
 
-  if (!('import' in document.createElement('link'))) {
+  // Check for native or polyfilled HTML imports support.
+  if (!('import' in document.createElement('link')) && !('HTMLImports' in window)) {
     let name = config.aurelia.loader.normalizeSync('aurelia-html-import-template-loader');
     let importsName = config.aurelia.loader.normalizeSync('webcomponentsjs/HTMLImports.min', name);
     return config.aurelia.loader.loadModule(importsName);


### PR DESCRIPTION
The current detection mechanism does not work with an already-loaded HTMLImports polyfill, only native support. If the polyfill is loaded, the template loader requires it again, which can cause duplicate definition errors when web components are loaded twice.
